### PR TITLE
fix: preserve spaces in DSML tool parameter names

### DIFF
--- a/deepseek-recipe/src/stream/state_machine.rs
+++ b/deepseek-recipe/src/stream/state_machine.rs
@@ -302,12 +302,18 @@ impl State {
             }
             Stage::ToolCallArguments { is_leading } => {
                 match_branches.new_string_branch(
-                    "parameter name=",
+                    "parameter name=\"",
                     Stage::ToolCallParamName,
                     if is_leading {
-                        ActionOnMatched::LabelToolCallArguments { label: "{", id: 0 }
+                        ActionOnMatched::LabelToolCallArguments {
+                            label: "{\"",
+                            id: 0,
+                        }
                     } else {
-                        ActionOnMatched::LabelToolCallArguments { label: ", ", id: 1 }
+                        ActionOnMatched::LabelToolCallArguments {
+                            label: ", \"",
+                            id: 1,
+                        }
                     },
                 );
                 match_branches.new_string_branch(
@@ -323,9 +329,12 @@ impl State {
             }
             Stage::ToolCallParamName => {
                 match_branches.new_string_branch(
-                    " ",
+                    "\"",
                     Stage::ToolCallParamType,
-                    ActionOnMatched::LabelToolCallArguments { label: ": ", id: 2 },
+                    ActionOnMatched::LabelToolCallArguments {
+                        label: "\": ",
+                        id: 2,
+                    },
                 );
                 ActionOnUnmatched::RawToolCallArguments { string: false }
             }

--- a/deepseek-recipe/tests/stream_tool_calls.rs
+++ b/deepseek-recipe/tests/stream_tool_calls.rs
@@ -1,0 +1,75 @@
+use deepseek_recipe::openai::chat_completion::response::{
+    ChatCompletionChunkGenerator, ChatCompletionFinishReason, ChatCompletionResponse,
+};
+use deepseek_recipe::response::ProtocolResponse;
+use deepseek_recipe::stream::state_machine::ParsingOptions;
+use deepseek_recipe::stream::{InferenceChunk, InferenceFinishReason, StreamProcessor};
+use deepseek_recipe::util::append_delta::AppendDelta;
+use serde_json::{Value, json};
+use tokio_stream::{StreamExt, iter};
+
+async fn assert_tool_arguments(chunks: Vec<String>, expected: &Value) {
+    let generator = ChatCompletionChunkGenerator::new("id".into(), "model".into(), false, false);
+    let processor = StreamProcessor::new(generator, ParsingOptions::default());
+    let inference = chunks
+        .into_iter()
+        .map(|content| InferenceChunk::Text {
+            content,
+            content_tokens: 0,
+        })
+        .chain(std::iter::once(InferenceChunk::Finish {
+            finish_reason: InferenceFinishReason::Stop,
+        }));
+    let mut stream = std::pin::pin!(processor.process(iter(inference)));
+    let mut response = ChatCompletionResponse::new("id".into(), "model".into(), 0, 0, 0);
+    while let Some(chunk) = stream.next().await {
+        response.append(chunk.unwrap());
+    }
+    let [choice] = response.choices.as_slice() else {
+        panic!("expected one completion");
+    };
+    assert_eq!(
+        choice.finish_reason,
+        Some(ChatCompletionFinishReason::ToolCalls)
+    );
+    let [call] = choice.message.tool_calls.as_deref().unwrap() else {
+        panic!("expected one tool call");
+    };
+    assert_eq!(call.function.name, "submit");
+    assert_eq!(
+        serde_json::from_str::<Value>(&call.function.arguments).unwrap(),
+        *expected
+    );
+}
+
+#[tokio::test]
+async fn quoted_tool_parameter_names_survive_chunk_boundaries() {
+    let expected = json!({
+        "shipping address": "Paris\n日本",
+        " string= mode ": {"enabled": true},
+        "count": 2,
+        "": "empty key",
+    });
+    // V4 and V4.1 use the same quoted attributes, with different DSML tag names.
+    for (block, prefix) in [("tool_calls", ""), (" calls", " ")] {
+        let output = format!(
+            "<｜DSML｜{block}>\n\
+             <｜DSML｜{prefix}invoke name=\"submit\">\n\
+             <｜DSML｜{prefix}parameter name=\"shipping address\" string=\"true\">Paris\n日本</｜DSML｜{prefix}parameter>\n\
+             <｜DSML｜{prefix}parameter name=\" string= mode \" string=\"false\">{{\"enabled\":true}}</｜DSML｜{prefix}parameter>\n\
+             <｜DSML｜{prefix}parameter name=\"count\" string=\"false\">2</｜DSML｜{prefix}parameter>\n\
+             <｜DSML｜{prefix}parameter name=\"\" string=\"true\">empty key</｜DSML｜{prefix}parameter>\n\
+             </｜DSML｜{prefix}invoke>\n\
+             </｜DSML｜{block}>"
+        );
+        assert_tool_arguments(vec![output.clone()], &expected).await;
+        for (split, _) in output.char_indices().skip(1) {
+            assert_tool_arguments(
+                vec![output[..split].to_string(), output[split..].to_string()],
+                &expected,
+            )
+            .await;
+        }
+        assert_tool_arguments(output.chars().map(|ch| ch.to_string()).collect(), &expected).await;
+    }
+}


### PR DESCRIPTION
I changed the DSML parameter-name transition to end at the closing quote rather than the next space. Names such as `shipping address` now produce valid JSON keys without losing leading or trailing spaces.

Validation:
- The new regression fails on the original parser and passes with the fix for V4 and V4.1, including every UTF-8-safe two-chunk split and character-sized chunks.
- The protocol-focused Rust suite passes: 6 tests across 8 suites.
- The real decoder HTTP service now returns the expected arguments in Chat Completions, Responses, and Messages formats. The original service returned malformed JSON or an empty argument object.
- Formatting, Clippy with warnings denied, and documentation builds pass for the affected protocol packages.

I did not build the OpenCV-dependent image/Python components.

I used AI assistance for the implementation and regression coverage. The checks above were run through that workflow.
