### PR TITLE
fix: treat retryable image failures as server-side in the example server

### DIFF
--- a/server-py/main.py
+++ b/server-py/main.py
@@ -113,7 +113,11 @@ def prepare_request(
             resolver = ImageResolver(ReqwestImageFetcher(), OpenCvImagePreprocessor())
             multimodal = resolver.resolve(rendered.image_sources, ImageQuota())
         except ImageError as error:
-            status_code = 500 if error.kind in {"Client", "TokenBudget"} else 400
+            # `is_retryable` marks the upstream failures a client may retry; `Client`
+            # is this server's own HTTP client failing to build.
+            status_code = (
+                500 if error.is_retryable or error.kind in {"Client", "TokenBudget"} else 400
+            )
             raise RequestError(str(error), status_code) from error
         images = multimodal.images
         try:

--- a/server-py/tests/test_smoke.py
+++ b/server-py/tests/test_smoke.py
@@ -1,6 +1,9 @@
 """Smoke tests for the FastAPI example and its inference callback."""
 
 import importlib.util
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -121,3 +124,66 @@ def test_web_search_conversion_options():
     assert accepted.status_code == 200, accepted.text
     assert response_text("/v1/messages", accepted.json()) == "Hello world!"
     assert rejected.status_code == 400
+
+
+class _StubImageHost(BaseHTTPRequestHandler):
+    """A local origin that answers every GET with a fixed status code."""
+
+    status = 503
+
+    def do_GET(self):  # noqa: N802
+        self.send_response(self.status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+@contextmanager
+def image_host(status):
+    """Serve one image URL whose origin always answers `status`."""
+    _StubImageHost.status = status
+    server = HTTPServer(("127.0.0.1", 0), _StubImageHost)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/image.png"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.parametrize(
+    "upstream,expected_status,expected_type",
+    [(503, 500, "internal_error"), (404, 400, "invalid_request_error")],
+)
+def test_image_fetch_failure_follows_retryability(
+    upstream, expected_status, expected_type
+):
+    """An upstream image failure is the server's to own only when it is retryable.
+
+    `ImageError.is_retryable` is the library's classification: `Fetch` is always
+    retryable and `FetchStatus` is retryable at 5xx. Answering a retryable upstream
+    failure with 400 tells the client its request was malformed and should not be
+    retried, which inverts the classification the library hands over.
+    """
+    with image_host(upstream) as url:
+        with TestClient(SERVER.app) as client:
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "deepseek-flash",
+                    "stream": False,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "describe this"},
+                                {"type": "image_url", "image_url": {"url": url}},
+                            ],
+                        }
+                    ],
+                },
+            )
+    assert response.status_code == expected_status, response.text
+    assert response.json()["error"]["type"] == expected_type


### PR DESCRIPTION
`server-py/main.py` picks the HTTP status for an `ImageError` out of a hardcoded set of two names:

```python
status_code = 500 if error.kind in {"Client", "TokenBudget"} else 400
```

`ImageError` also carries `is_retryable`, and `deepseek-recipe-image/src/error.rs:99-111` documents what it means: `Fetch` is retryable regardless of its source, and `FetchStatus` is retryable at 5xx. Neither name is in that set, so both are answered `400 invalid_request_error` - the client is told its request was malformed and should not be retried, which is the opposite of the classification the library hands over on the exception object.

## Measured on the published wheel

`deepseek-recipe==0.1.1`, `manylinux_2_28_x86_64`, imported directly. `ImageResolver` was pointed at a local stdlib HTTP server, so nothing here needs egress; the last row uses a closed port.

| upstream condition | `error.kind` | `error.is_retryable` | status today |
| --- | --- | --- | --- |
| upstream answers 503 | `FetchStatus` | `True` | **400** `invalid_request_error` |
| connection refused | `Fetch` | `True` | **400** `invalid_request_error` |
| upstream answers 404 | `FetchStatus` | `False` | 400 `invalid_request_error` |
| 200 with a non-image body | `UnsupportedMediaType` | `False` | 400 `invalid_request_error` |

An upstream image host answering 503 is therefore reported to the API client as the client's own mistake.

## Why `Client` and `TokenBudget` stay at 500

That set is not wrong, only incomplete, so this keeps both entries:

- `Client` is documented as "The HTTP client could not be constructed" (`deepseek-recipe-image/src/error.rs:93-95`) - this server's own failure.
- `TokenBudget` wraps `CalcResizeError`, and the branch immediately below already answers that same failure with 500:

```python
except CalcResizeError as error:
    raise RequestError(str(error), 500) from error
```

## Change

One condition added; nothing else moves.

```diff
-            status_code = 500 if error.kind in {"Client", "TokenBudget"} else 400
+            status_code = (
+                500 if error.is_retryable or error.kind in {"Client", "TokenBudget"} else 400
+            )
```

I did not add a regression test. `server-py/tests/test_smoke.py` has no image-error coverage, and reproducing this needs a controllable upstream that the suite does not currently stand up. Happy to add one with a local stub server if you would like it.